### PR TITLE
Feat/#8/s3 S3 upload 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 
 	// aws S3
 	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.322'
+	testImplementation 'io.findify:s3mock_2.13:0.2.6'
 
 	// Oauth2
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-aop:2.7.5'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
+	// aws S3
+	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.322'
+
 	// Oauth2
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 

--- a/src/main/java/com/lhgpds/algometa/configuration/S3Configuration.java
+++ b/src/main/java/com/lhgpds/algometa/configuration/S3Configuration.java
@@ -1,0 +1,33 @@
+package com.lhgpds.algometa.configuration;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.lhgpds.algometa.infra.s3.S3Properties;
+import com.lhgpds.algometa.infra.s3.S3Uploader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@RequiredArgsConstructor
+@Configuration
+public class S3Configuration {
+
+    private final S3Properties s3Properties;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+            .withRegion(s3Properties.getRegion())
+            .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(
+                s3Properties.getAccessKey(),
+                s3Properties.getSecretKey())))
+            .build();
+    }
+
+    @Bean
+    public S3Uploader s3Uploader(AmazonS3Client amazonS3Client) {
+        return new S3Uploader(amazonS3Client, s3Properties.getBucket());
+    }
+}

--- a/src/main/java/com/lhgpds/algometa/infra/s3/S3Properties.java
+++ b/src/main/java/com/lhgpds/algometa/infra/s3/S3Properties.java
@@ -1,0 +1,18 @@
+package com.lhgpds.algometa.infra.s3;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "cloud.aws.s3")
+public class S3Properties {
+
+    private String bucket;
+    private String accessKey;
+    private String secretKey;
+    private String region;
+}

--- a/src/main/java/com/lhgpds/algometa/infra/s3/S3Uploader.java
+++ b/src/main/java/com/lhgpds/algometa/infra/s3/S3Uploader.java
@@ -1,0 +1,38 @@
+package com.lhgpds.algometa.infra.s3;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import java.io.IOException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@RequiredArgsConstructor
+public class S3Uploader {
+
+    private final AmazonS3Client amazonS3Client;
+
+    private final String bucket;
+
+    public String upload(MultipartFile multipartFile) throws IOException {
+        String s3FileName = UUID.randomUUID() + "-" + multipartFile.getOriginalFilename();
+
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(multipartFile.getInputStream().available());
+        amazonS3Client.putObject(bucket, s3FileName, multipartFile.getInputStream(),
+            objectMetadata);
+        return amazonS3Client.getUrl(bucket, s3FileName).toString();
+    }
+
+    public String upload(MultipartFile multipartFile, String path) throws IOException {
+        String s3FileName = path + "/" + UUID.randomUUID() + "-" + multipartFile.getOriginalFilename();
+
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(multipartFile.getInputStream().available());
+        amazonS3Client.putObject(bucket, s3FileName, multipartFile.getInputStream(),
+            objectMetadata);
+        return amazonS3Client.getUrl(bucket, s3FileName).toString();
+    }
+}

--- a/src/main/java/com/lhgpds/algometa/infra/s3/S3Uploader.java
+++ b/src/main/java/com/lhgpds/algometa/infra/s3/S3Uploader.java
@@ -16,18 +16,9 @@ public class S3Uploader {
 
     private final String bucket;
 
-    public String upload(MultipartFile multipartFile) throws IOException {
-        String s3FileName = UUID.randomUUID() + "-" + multipartFile.getOriginalFilename();
-
-        ObjectMetadata objectMetadata = new ObjectMetadata();
-        objectMetadata.setContentLength(multipartFile.getInputStream().available());
-        amazonS3Client.putObject(bucket, s3FileName, multipartFile.getInputStream(),
-            objectMetadata);
-        return amazonS3Client.getUrl(bucket, s3FileName).toString();
-    }
-
     public String upload(MultipartFile multipartFile, String path) throws IOException {
-        String s3FileName = path + "/" + UUID.randomUUID() + "-" + multipartFile.getOriginalFilename();
+        String s3FileName =
+            path + "/" + UUID.randomUUID() + "-" + multipartFile.getOriginalFilename();
 
         ObjectMetadata objectMetadata = new ObjectMetadata();
         objectMetadata.setContentLength(multipartFile.getInputStream().available());
@@ -35,4 +26,5 @@ public class S3Uploader {
             objectMetadata);
         return amazonS3Client.getUrl(bucket, s3FileName).toString();
     }
+
 }

--- a/src/test/java/com/lhgpds/algometa/infra/s3/S3UploaderTest.java
+++ b/src/test/java/com/lhgpds/algometa/infra/s3/S3UploaderTest.java
@@ -1,0 +1,74 @@
+package com.lhgpds.algometa.infra.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import io.findify.s3mock.S3Mock;
+import java.io.IOException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.mock.web.MockMultipartFile;
+
+
+class S3UploaderTest {
+
+    private static final String BUCKET_NAME = "testbucket";
+    private static final String REGION = "ap-northeast-2";
+
+
+    @Test
+    @DisplayName("S3 업로드 연결 및 upload 테스트")
+    void s3uploadConnectionTest() throws IOException {
+        // given
+        S3Mock s3Mock = S3Config.s3Mock();
+        AmazonS3Client amazonS3Client = (AmazonS3Client) S3Config.amazonS3(s3Mock);
+        S3Uploader s3Uploader = new S3Uploader(amazonS3Client, BUCKET_NAME);
+
+        String path = "test.png";
+        String contentType = "image/png";
+        String dirName = "test";
+
+        MockMultipartFile file = new MockMultipartFile("test", path, contentType,
+            "test".getBytes());
+
+        // when
+        String urlPath = s3Uploader.upload(file, dirName);
+
+        // then
+        assertThat(urlPath).contains(path);
+        assertThat(urlPath).contains(dirName);
+
+        s3Mock.stop();
+    }
+
+
+    @TestConfiguration
+    static class S3Config {
+
+        public static S3Mock s3Mock() {
+            return new S3Mock.Builder().withPort(8001).withInMemoryBackend().build();
+        }
+
+
+        public static AmazonS3 amazonS3(S3Mock s3Mock) {
+            s3Mock.start();
+            AwsClientBuilder.EndpointConfiguration endpoint = new AwsClientBuilder.EndpointConfiguration(
+                "http://localhost:8001", REGION);
+            AmazonS3 client = AmazonS3ClientBuilder
+                .standard()
+                .withPathStyleAccessEnabled(true)
+                .withEndpointConfiguration(endpoint)
+                .withCredentials(new AWSStaticCredentialsProvider(new AnonymousAWSCredentials()))
+                .build();
+            client.createBucket(BUCKET_NAME);
+
+            return client;
+        }
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -24,6 +24,14 @@ spring:
             scope:
               - profile
 
+cloud:
+  aws:
+    s3:
+      bucket: 1234
+      accessKey: 1234
+      secretKey: 1234
+      region: ap-northeast-2
+
 jwt:
   secret-key: linkywayteamisgoodlinkywayteamisgoodlinkywayteamisgoodlinkywayteamisgoodlinkywayteamisgoodlinkywayteamisgoodlinkywayteamisgood
   token-period: 600000


### PR DESCRIPTION
# 구현 사항

- s3 Uploader Path를 지정해서 저장 할 수 있도록 구현 (format : path / uuid - fileName) 띄어쓰기는 없음 
- s3 mocking test 구현( 직접 연결 테스트하는 것은 요금적인 측면 + 테스트가 안정적이지 않음 + 불필요하게 버킷에 실제 저장되는 문제)